### PR TITLE
Change Double click item edit to single click

### DIFF
--- a/src/components/Transaction.vue
+++ b/src/components/Transaction.vue
@@ -13,7 +13,7 @@
                 <tr v-for="item in items" :key="item.name">
                     <td>{{ item.item.name }}</td>
                     <td>
-                        <span v-if="!item.editing" @dblclick="toggleEdit(item)">{{ item.numberOfItems }}</span>
+                        <span v-if="!item.editing" @click="toggleEdit(item)">{{ item.numberOfItems }}</span>
                         <input v-if="item.editing" @blur="toggleEdit(item)" type="number" v-model="item.numberOfItems">
                     </td>
                     <td>{{ item.numberOfItems * item.item.rate }}</td>


### PR DESCRIPTION
User can now edit the number of items with a single click instead of a double click on the number of items.